### PR TITLE
share help function between `help [command]` and `[command] help`

### DIFF
--- a/commands/country.js
+++ b/commands/country.js
@@ -4,36 +4,9 @@ const command = require('../functions/helper-command')
 const db = require('../mongo')
 const Discord = require('discord.js')
 
-exports.run = async (client, message, args) => {
-    let arg1 = command.getFirstOption(args);
+exports.run = command.buildRunner(countryCommand)
 
-    let option;
-    for (i = 0; i < countryCommand.options.length; i++) {
-        if (countryCommand.options[i].aliases.find(alias => countryCommand.optPrefix + alias === arg1)) {
-            option = countryCommand.options[i]
-            break
-        }
-    }
-    if (option) option.handler(message, args, client, countryCommand)
-    else handleEmpty(message, args, client, countryCommand)
-}
-
-const handleEmpty = (message, args, client, ecommand) => {
-    if (args.length > 1) {
-        let discordUser = message.mentions.users.first();
-        if (discordUser)
-            handleFrom(message, args, client);
-        else
-            handleWho(message, args, client);
-    }
-    else {
-        handleHelp(message, args, client, ecommand);
-    }
-}
-
-const handleHelp = (message, args, client, ecommand) => {
-    command.sendHelp(message, ecommand);
-}
+const handleHelp = command.handleHelp
 
 const handleSet = (message, args, client) => {
 
@@ -141,7 +114,7 @@ let countryCommand = {
         description: "If {mention}, will let you know where the user is from. If {country}, will return a list of users from said country.",
         params: '{mention | country string | country code} ',
         supportSpaces: true,
-        handler: handleEmpty
+        handler: command.handleEmpty
     },
     {
         aliases: ['help', 'halp'],

--- a/commands/country.js
+++ b/commands/country.js
@@ -6,7 +6,7 @@ const Discord = require('discord.js')
 
 exports.run = command.buildRunner(countryCommand)
 
-const handleHelp = command.handleHelp
+exports.help = command.buildHelp(countryCommand)
 
 const handleSet = (message, args, client) => {
 
@@ -121,7 +121,7 @@ let countryCommand = {
         description: "Will return a list of possible commands.",
         hide: true,
         params: '',
-        handler: handleHelp
+        handler: exports.help
     },
     {
         aliases: ['whofrom'],

--- a/commands/help.js
+++ b/commands/help.js
@@ -26,6 +26,11 @@ exports.run = (client, message, args) => {
         return
     }
 
+    if (typeof client.commands[searched].help === 'function') {
+        client.commands[searched].help(message)
+        return
+    }
+
     message.channel.send(client.commands[searched].help)
     // message.channel.send(`\`${process.env.BOT_PREFIX}${searched}\` — ${client.commands[searched].help}`)
 }

--- a/commands/tech.js
+++ b/commands/tech.js
@@ -5,33 +5,9 @@ const command = require('../functions/helper-command')
 const db = require('../mongo')
 const Discord = require('discord.js')
 
-exports.run = async (client, message, args) => {
-    let arg1 = command.getFirstOption(args)
+exports.run = command.buildRunner(techCommands)
 
-    let option
-    for (i = 0; i < techCommands.options.length; i++) {
-        if (techCommands.options[i].aliases.find((alias) => techCommands.optPrefix + alias === arg1)) {
-            option = techCommands.options[i]
-            break
-        }
-    }
-    if (option) option.handler(message, args, client, techCommands)
-    else handleEmpty(message, args, client, techCommands)
-}
-
-const handleEmpty = (message, args, client, ecommand) => {
-    if (args.length > 1) {
-        let discordUser = message.mentions.users.first()
-        if (discordUser) handleFrom(message, args, client)
-        else handleWho(message, args, client)
-    } else {
-        handleEmpty(message, args, client, ecommand)
-    }
-}
-
-const handleHelp = (message, args, client, ecommand) => {
-    command.sendHelp(message, ecommand)
-}
+const handleHelp = command.handleHelp
 
 const handleAdd = async (message, args, client) => {
     const discordUser = message.author
@@ -188,7 +164,7 @@ let techCommands = {
                 'If {+search techName} will show you a list of devs which use the technology, If {+add techName} will add a technology to your tech stack,If {+delete techName} will delete a technology from your tech stack.',
             params: '{techName}',
             supportSpaces: false,
-            handler: handleEmpty
+            handler: command.handleEmpty
         },
         {
             aliases: ['help', 'halp'],

--- a/commands/tech.js
+++ b/commands/tech.js
@@ -7,7 +7,7 @@ const Discord = require('discord.js')
 
 exports.run = command.buildRunner(techCommands)
 
-const handleHelp = command.handleHelp
+exports.help = command.buildHelp(techCommands)
 
 const handleAdd = async (message, args, client) => {
     const discordUser = message.author
@@ -171,7 +171,7 @@ let techCommands = {
             description: 'Will return a list of possible commands.',
             hide: true,
             params: '',
-            handler: handleHelp
+            handler: exports.help
         },
         {
             aliases: ['add', 'save'],

--- a/functions/helper-command.js
+++ b/functions/helper-command.js
@@ -71,6 +71,6 @@ exports.handleEmpty = (message, args, client, ecommand) => {
     }
 }
 
-exports.handleHelp = (message, args, client, ecommand) => {
-    exports.sendHelp(message, ecommand);
+exports.buildHelp = config => (message, args, client, ecommand) => {
+    exports.sendHelp(message, config)
 }

--- a/functions/helper-command.js
+++ b/functions/helper-command.js
@@ -46,3 +46,31 @@ exports.sendHelp = (message, commandObj) => {
     }   
     message.channel.send(embed);   
 }
+
+exports.buildRunner = config => async (client, message, args) => {
+    let arg1 = exports.getFirstOption(args)
+
+    let option
+    for (i = 0; i < config.options.length; i++) {
+        if (config.options[i].aliases.find((alias) => config.optPrefix + alias === arg1)) {
+            option = config.options[i]
+            break
+        }
+    }
+    if (option) option.handler(message, args, client, config)
+    else handleEmpty(message, args, client, config)
+}
+
+exports.handleEmpty = (message, args, client, ecommand) => {
+    if (args.length > 1) {
+        let discordUser = message.mentions.users.first()
+        if (discordUser) handleFrom(message, args, client)
+        else handleWho(message, args, client)
+    } else {
+        handleEmpty(message, args, client, ecommand)
+    }
+}
+
+exports.handleHelp = (message, args, client, ecommand) => {
+    exports.sendHelp(message, ecommand);
+}


### PR DESCRIPTION
### ⚠️ This hasn't been tested yet, because I don't know how to test bot branches in discord! ⚠️ 

This modifies the "complex" commands (those with a list of subcommands) to route the `[command] help` subcommand to a shared handler with `help [command]`. This way the `help [command]` handler will give detailed information using the embed created in the command.sendHelp function.

1. Create helper abstractions for common functions (run, help, empty)
2. Export a help function from commands using the new abstraction
3. Adjust the central help command to handle functions
4. Route the existing help subcommands to the new help function

This fixes #38 